### PR TITLE
[JIYOUNG] SearchPage, MainView

### DIFF
--- a/backend/src/main/java/ds/pirate/backend/service/ArticleService/ArticleServiceImpl.java
+++ b/backend/src/main/java/ds/pirate/backend/service/ArticleService/ArticleServiceImpl.java
@@ -436,6 +436,18 @@ public class ArticleServiceImpl implements ArticleService {
                 return new EmbedCard(v);
             }).collect(Collectors.toList());
             return result;
+        } else if (vo.getOrder().equals("like")) {
+            Sort sort = sortByLikeCount();
+            List<EmbedCard> result = repo.getListAndAuthor(sort).get().stream().map(v->{
+                return new EmbedCard(v);
+            }).collect(Collectors.toList());
+            return result;
+        } else if (vo.getOrder().equals("star")) {
+            Sort sort = sortByArticleRate();
+            List<EmbedCard> result = repo.getListAndAuthor(sort).get().stream().map(v->{
+                return new EmbedCard(v);
+            }).collect(Collectors.toList());
+            return result;
         } else {
         Sort sort = sortByAid();
         List<EmbedCard> result = repo.getListAndAuthor(sort).get().stream().map(v -> {

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -51,11 +51,11 @@ export default {
           search: "null",
           order: a
         }
+        state.cards = null;
         console.log(body);
         await axios.post(url, body, {headers}).then(function (res) {
           console.log("3. 시작");
           console.log(res.data);
-          state.cards = null;
           state.cards = res.data;
           console.log("4. 끝")
         })
@@ -65,11 +65,20 @@ export default {
     async function view (){
       order("view")
     }
+    async function like (){
+      order("like")
+    }
+    async function star (){
+      order("star")
+    }
+    async function latest (){
+      order("latest")
+    }
 
     getCardsInformation()
 
 
-    return {state, view}
+    return {state, view, like, star, latest}
   }
 }
 

--- a/frontend/src/views/SearchList.vue
+++ b/frontend/src/views/SearchList.vue
@@ -52,11 +52,11 @@ export default {
         search: searchword,
         order: orderword
       }
+      state.cards = null;
       console.log("2." + body);
       await axios.post(url, body, {headers}).then(function (res){
         console.log("3. 시작");
         console.log(res.data);
-        state.cards = 0;
         state.cards = res.data;
         console.log("4. 끝")
       })
@@ -64,24 +64,22 @@ export default {
 
     async function view (){
       await router.push(`/search?cards=${searchword}&order=view`);
-      await router.go(0)
+      getCardsInformation()
     }
 
     async function latest(){
       await router.push(`/search?cards=${searchword}&order=new`);
-      await router.go(0)
+      getCardsInformation()
     }
 
     async function star(){
       await router.push(`/search?cards=${searchword}&order=star`);
       getCardsInformation()
-      await router.go(0)
     }
 
     async function like(){
       await router.push(`/search?cards=${searchword}&order=like`);
       getCardsInformation()
-      await router.go(0)
     }
 
       getCardsInformation()


### PR DESCRIPTION
+22.09.25
검색 할 때, 분류별 정렬 버튼에 새로고침 코드를 넣지 않아도 결과가 출력되게 수정.
메인 페이지 분류별 출력(조회순, 좋아요순, 평점순, 최신순)